### PR TITLE
Re-introduce Ruby 2.3 support and test Jekyll 3.7+

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ inherit_gem:
   rubocop-jekyll: .rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.3
   Exclude:
     - script/**/*
     - vendor/**/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.6
+  - &latest_ruby 2.6
   - 2.4
+  - 2.3
 git:
   depth: 3
 
@@ -22,4 +23,13 @@ script: script/cibuild
 
 env:
   global:
-  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+  matrix:
+    - JEKYLL_VERSION="~> 3.8"
+
+matrix:
+  include:
+    - rvm: *latest_ruby
+      env: JEKYLL_VERSION="~> 3.7.4"
+    - rvm: *latest_ruby
+      env: JEKYLL_VERSION=">= 4.0.0.pre.alpha1"

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@
 source "https://rubygems.org"
 gemspec
 
-gem "jekyll", "~> #{ENV["JEKYLL_VERSION"]}" if ENV["JEKYLL_VERSION"]
+gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,14 +3,19 @@ clone_depth: 5
 build: off
 
 install:
-  - SET PATH=C:\Ruby%RUBY_FOLDER_VER%\bin;%PATH%
+  - SET PATH=C:\Ruby%RUBY_FOLDER_VER%-x64\bin;%PATH%
   - bundle install --retry 5 --jobs=%NUMBER_OF_PROCESSORS% --clean --path vendor\bundle
 
 environment:
+  JEKYLL_VERSION: "~> 3.8"
   matrix:
-    - RUBY_FOLDER_VER: "25"
-    - RUBY_FOLDER_VER: "25-x64"
+    - RUBY_FOLDER_VER: "26"
+      JEKYLL_VERSION : "~> 3.7.4"
+    - RUBY_FOLDER_VER: "26"
+      JEKYLL_VERSION : ">= 4.0.0.pre.alpha1"
+    - RUBY_FOLDER_VER: "26"
     - RUBY_FOLDER_VER: "24"
+    - RUBY_FOLDER_VER: "23"
 
 test_script:
   - ruby --version

--- a/jekyll-commonmark.gemspec
+++ b/jekyll-commonmark.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r!^(test|spec|features)/!)
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_ruby_version = ">= 2.3.0"
 
   spec.add_runtime_dependency "commonmarker", "~> 0.14"
   spec.add_runtime_dependency "jekyll", ">= 3.7", "< 5.0"


### PR DESCRIPTION
The plugin doesn't use Ruby 2.4 specific code. So we can relax the Ruby version constraint to Ruby 2.3