### PR TITLE
docs: Remove gemnasium badge (no longer available)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,6 @@
 [![Gem Version](https://img.shields.io/gem/v/jekyll-commonmark.svg)](https://rubygems.org/gems/jekyll-commonmark)
 [![Build Status](https://img.shields.io/travis/jekyll/jekyll-commonmark/master.svg)](https://travis-ci.org/jekyll/jekyll-commonmark)
 [![Windows Build status](https://img.shields.io/appveyor/ci/pathawks/jekyll-commonmark/master.svg?label=Windows%20build)](https://ci.appveyor.com/project/pathawks/jekyll-commonmark)
-[![Dependency Status](https://img.shields.io/gemnasium/pathawks/jekyll-commonmark.svg)](https://gemnasium.com/pathawks/jekyll-commonmark)
 
 Jekyll Markdown converter that uses [libcmark](https://github.com/jgm/CommonMark), the reference parser for CommonMark. 
 As a result, it is faster than Kramdown.
@@ -36,5 +35,4 @@ To specify [extensions](https://github.com/gjtorikian/commonmarker#extensions) a
 commonmark:
   options: ["SMART", "FOOTNOTES"]
   extensions: ["strikethrough", "autolink", "table"]
- ```
- 
+```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,6 @@ environment:
       JEKYLL_VERSION : ">= 4.0.0.pre.alpha1"
     - RUBY_FOLDER_VER: "26"
     - RUBY_FOLDER_VER: "24"
-    - RUBY_FOLDER_VER: "23"
 
 test_script:
   - ruby --version


### PR DESCRIPTION
Since May 15, 2018, the services provided by Gemnasium are no longer available. The account was automatically closed. There is no reason to keep this badge.

More information here: https://docs.gitlab.com/ee/user/project/import/gemnasium.html