### PR TITLE
Update README to link to commonmarker

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@
 [![Build Status](https://img.shields.io/travis/jekyll/jekyll-commonmark/master.svg)](https://travis-ci.org/jekyll/jekyll-commonmark)
 [![Windows Build status](https://img.shields.io/appveyor/ci/pathawks/jekyll-commonmark/master.svg?label=Windows%20build)](https://ci.appveyor.com/project/pathawks/jekyll-commonmark)
 
-Jekyll Markdown converter that uses [libcmark](https://github.com/jgm/CommonMark), the reference parser for CommonMark. 
+Jekyll Markdown converter that uses [libcmark](https://github.com/jgm/CommonMark) (via [commonmarker](https://github.com/gjtorikian/commonmarker)), the reference parser for CommonMark. 
 As a result, it is faster than Kramdown.
 
 GitHub Pages supports CommonMark through https://github.com/github/jekyll-commonmark-ghpages

--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@
 [![Build Status](https://img.shields.io/travis/jekyll/jekyll-commonmark/master.svg)](https://travis-ci.org/jekyll/jekyll-commonmark)
 [![Windows Build status](https://img.shields.io/appveyor/ci/pathawks/jekyll-commonmark/master.svg?label=Windows%20build)](https://ci.appveyor.com/project/pathawks/jekyll-commonmark)
 
-Jekyll Markdown converter that uses [libcmark](https://github.com/jgm/CommonMark) (via [commonmarker](https://github.com/gjtorikian/commonmarker)), the reference parser for CommonMark. 
+Jekyll Markdown converter that uses [libcmark-gfm](https://github.com/github/cmark-gfm) (via [commonmarker](https://github.com/gjtorikian/commonmarker)). 
 As a result, it is faster than Kramdown.
 
 GitHub Pages supports CommonMark through https://github.com/github/jekyll-commonmark-ghpages


### PR DESCRIPTION
Since this library actually seems to use commonmarker as an intermediary to ~`libcmark`~ `libcmark-gfm`, I thought it would be good to more explicitly reference it up front.

The options/extensions/etc links later on in this readme already link out to the commonmarker repo.

Updated to reflect the current state of transitively using `libcmark-gfm` as per https://github.com/jekyll/jekyll-commonmark/issues/39#issuecomment-662162062