### PR TITLE
remove SMART from readme example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,6 +33,6 @@ To specify [extensions](https://github.com/gjtorikian/commonmarker#extensions) a
 
 ```yaml
 commonmark:
-  options: ["SMART", "FOOTNOTES"]
+  options: ["FOOTNOTES"]
   extensions: ["strikethrough", "autolink", "table"]
 ```


### PR DESCRIPTION
Unicode "smart" quotes are the bane of dev-content centric text rendering, and should be nuked from orbit. 

Until that happens, discouraging the use of smart quote rendering is a good thing.

This PR removes the smart option from the sample, so devs new to commonmark aren't inclined to activate smart quotes when copying from the sample.

Cheers,