### PR TITLE
Restrict CommonMarker to <0.22

### DIFF
--- a/jekyll-commonmark.gemspec
+++ b/jekyll-commonmark.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4.0"
 
-  spec.add_runtime_dependency "commonmarker", "~> 0.14"
+  spec.add_runtime_dependency "commonmarker", "~> 0.14", "<0.22"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "jekyll", ">= 3.7", "< 5.0"


### PR DESCRIPTION
I can follow up with a compability patch but as it is, jekyll-commonmark installs commonmark 0.22 and it breaks sites