### PR TITLE
Require at least commonmarker-0.22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 cache: bundler
 rvm:
   - &latest_ruby 2.7
-  - 2.5
+  - 2.6
 git:
   depth: 3
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,14 +7,14 @@ install:
   - bundle install --retry 5 --jobs=%NUMBER_OF_PROCESSORS% --clean --path vendor\bundle
 
 environment:
-  JEKYLL_VERSION: "~> 3.8"
+  JEKYLL_VERSION: "~> 4.0"
   matrix:
     - RUBY_FOLDER_VER: "26"
+      JEKYLL_VERSION : "~> 3.9.0"
+    - RUBY_FOLDER_VER: "26"
+      JEKYLL_VERSION : "~> 3.8.7"
+    - RUBY_FOLDER_VER: "26"
       JEKYLL_VERSION : "~> 3.7.4"
-    - RUBY_FOLDER_VER: "26"
-      JEKYLL_VERSION : ">= 4.0.0.pre.alpha1"
-    - RUBY_FOLDER_VER: "26"
-    - RUBY_FOLDER_VER: "24"
 
 test_script:
   - ruby --version

--- a/jekyll-commonmark.gemspec
+++ b/jekyll-commonmark.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r!^(test|spec|features)/!)
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_ruby_version = ">= 2.6.0"
 
   spec.add_runtime_dependency "commonmarker", "~> 0.22"
 

--- a/jekyll-commonmark.gemspec
+++ b/jekyll-commonmark.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4.0"
 
-  spec.add_runtime_dependency "commonmarker", "~> 0.14"
+  spec.add_runtime_dependency "commonmarker", "~> 0.22"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "jekyll", ">= 3.7", "< 5.0"

--- a/lib/jekyll-commonmark.rb
+++ b/lib/jekyll-commonmark.rb
@@ -8,8 +8,8 @@ module Jekyll
     class Markdown
       class CommonMark
         DEFAULT_CONFIG = { "extensions" => [], "options" => [] }.freeze
-        PARSE_KEYS = CommonMarker::Config::Parse.keys
-        RENDER_KEYS = CommonMarker::Config::Render.keys
+        PARSE_KEYS = CommonMarker::Config::OPTS[:parse].keys
+        RENDER_KEYS = CommonMarker::Config::OPTS[:render].keys
         VALID_EXTENSIONS = CommonMarker.extensions.collect(&:to_sym)
         VALID_OPTIONS = (PARSE_KEYS + RENDER_KEYS).uniq
 


### PR DESCRIPTION
Commonmarker v0.22 stopped using `ruby-enum` and replaced two classes under the `CommonMarker::Config` namespace in the commit https://github.com/gjtorikian/commonmarker/commit/ea0f742d9df6c035db5aacdbfb62a0f6679f960e

That broke our plugin.

Therefore, implement a foward-looking change and drop support for older versions of Commonmarker.