### PR TITLE
Clean up gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,9 @@ AllCops:
 
 Layout/LineEndStringConcatenationIndentation:
   Enabled: true
+Layout/LineLength:
+  Exclude:
+    - jekyll-commonmark.gemspec
 
 Lint/EmptyInPattern:
   Enabled: false

--- a/jekyll-commonmark.gemspec
+++ b/jekyll-commonmark.gemspec
@@ -8,12 +8,10 @@ Gem::Specification.new do |spec|
   spec.version       = Jekyll::CommonMark::VERSION
   spec.authors       = ["Pat Hawks"]
   spec.email         = "pat@pathawks.com"
-  spec.homepage      = "https://github.com/pathawks/jekyll-commonmark"
+  spec.homepage      = "https://github.com/jekyll/jekyll-commonmark"
   spec.licenses      = ["MIT"]
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r!^bin/!) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r!^(test|spec|features)/!)
+  spec.files         = `git ls-files lib -z`.split("\x0").concat(%w(LICENSE Readme.md))
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"

--- a/jekyll-commonmark.gemspec
+++ b/jekyll-commonmark.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/jekyll/jekyll-commonmark"
   spec.licenses      = ["MIT"]
 
-  spec.files         = `git ls-files lib -z`.split("\x0").concat(%w(LICENSE Readme.md))
+  spec.files         = `git ls-files lib -z`.split("\x0").concat(%w(LICENSE Readme.md History.markdown))
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.6.0"


### PR DESCRIPTION
- Fix project homepage URL.
- Bundle only lib_files, License, README and History.markdown in the gem. (*instead of [everything in the repository](https://github.com/jekyll/jekyll-commonmark/runs/3688439299#step:5:4)*)