### PR TITLE
Refactor away extra abstractions

### DIFF
--- a/lib/jekyll-commonmark.rb
+++ b/lib/jekyll-commonmark.rb
@@ -1,56 +1,39 @@
 # frozen-string-literal: true
 
-Jekyll::External.require_with_graceful_fail "commonmarker"
-require_relative "jekyll-commonmark/html_renderer"
-
 module Jekyll
   module Converters
     class Markdown
       class CommonMark
-        DEFAULT_CONFIG = { "extensions" => [], "options" => [] }.freeze
-        PARSE_KEYS = CommonMarker::Config::OPTS[:parse].keys
-        RENDER_KEYS = CommonMarker::Config::OPTS[:render].keys
-        VALID_EXTENSIONS = CommonMarker.extensions.collect(&:to_sym)
-        VALID_OPTIONS = (PARSE_KEYS + RENDER_KEYS).uniq
-
-        private_constant :DEFAULT_CONFIG, :PARSE_KEYS, :RENDER_KEYS,
-                         :VALID_EXTENSIONS, :VALID_OPTIONS
+        autoload :HtmlRenderer, "jekyll-commonmark/html_renderer"
 
         def initialize(config)
-          @config = config["commonmark"] || DEFAULT_CONFIG
+          Jekyll::External.require_with_graceful_fail "commonmarker"
 
-          @parse_options = options & PARSE_KEYS
-          @render_options = options & RENDER_KEYS
+          parse_keys  = CommonMarker::Config::OPTS[:parse].keys
+          render_keys = CommonMarker::Config::OPTS[:render].keys
 
-          @parse_options = :DEFAULT if @parse_options.empty?
+          options = setup_options(config, parse_keys, render_keys)
+          options_set = Set.new(options)
+
+          @extensions = setup_extensions(config)
+
+          @parse_options  = (options_set & parse_keys).to_a
+          @render_options = (options_set & render_keys).to_a
+
+          @parse_options  = :DEFAULT if @parse_options.empty?
           @render_options = :DEFAULT if @render_options.empty?
         end
 
         def convert(content)
           HtmlRenderer.new(
-            :options    => render_options,
-            :extensions => extensions
+            :options    => @render_options,
+            :extensions => @extensions
           ).render(
-            CommonMarker.render_doc(content, parse_options, extensions)
+            CommonMarker.render_doc(content, @parse_options, @extensions)
           )
         end
 
         private
-
-        attr_reader :config, :parse_options, :render_options
-
-        def extensions
-          @extensions ||= prepare("extensions", ->(item) { item.to_sym }, VALID_EXTENSIONS)
-        end
-
-        def options
-          @options ||= prepare("options", ->(item) { item.upcase.to_sym }, VALID_OPTIONS)
-        end
-
-        def prepare(key, proc, valid_keys)
-          collection = config[key].map(&proc)
-          validate(collection, valid_keys, key[0..-2])
-        end
 
         def validate(list, bucket, type)
           list.reject do |item|
@@ -60,6 +43,22 @@ module Jekyll
             Jekyll.logger.info "Valid #{type}s:", bucket.join(", ")
             true
           end
+        end
+
+        def setup_options(config, parse_keys, render_keys)
+          options    = config["commonmark"]["options"].collect { |e| e.upcase.to_sym }
+          valid_opts = Set.new(parse_keys + render_keys).to_a
+          validate(options, valid_opts, "option")
+        rescue NoMethodError
+          []
+        end
+
+        def setup_extensions(config)
+          extensions       = config["commonmark"]["extensions"].collect(&:to_sym)
+          valid_extensions = CommonMarker.extensions.collect(&:to_sym)
+          validate(extensions, valid_extensions, "extension")
+        rescue NoMethodError
+          []
         end
       end
     end


### PR DESCRIPTION
## Summary

- lazy load Commonmarker and our `HtmlRenderer` class.
- Replace class constants with local variables since Commonmarker is not loaded eagerly.
- Preserve behavior from `v1.3.1` by removing use of `DEFAULT_CONFIG`.

## Context

Closes #49 