### PR TITLE
Bump commonmarker from v0.22 to v0.23.4

### DIFF
--- a/jekyll-commonmark.gemspec
+++ b/jekyll-commonmark.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.6.0"
 
-  spec.add_runtime_dependency "commonmarker", "~> 0.22"
+  spec.add_runtime_dependency "commonmarker", "~> 0.23.4"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "jekyll", ">= 3.7", "< 5.0"


### PR DESCRIPTION
## Impact

CommonMarker uses cmark-gfm for rendering [Github Flavored Markdown](https://github.github.com/gfm/). An [integer overflow in cmark-gfm's table row parsing](https://github.com/github/cmark-gfm/security/advisories/GHSA-mc3g-88wq-6f4x) may lead to heap memory corruption when parsing tables who's marker rows contain more than UINT16_MAX columns. The impact of this heap corruption ranges from Information Leak to Arbitrary Code Execution.

If affected versions of CommonMarker are used for rendering remote user controlled markdown, this vulnerability may lead to Remote Code Execution (RCE).

## Patches

This vulnerability has been patched in the following CommonMarker release:

v0.23.4

## References

[GHSA-mc3g-88wq-6f4x](https://github.com/github/cmark-gfm/security/advisories/GHSA-mc3g-88wq-6f4x)