### PR TITLE
change class for boolean in tests

### DIFF
--- a/spec/jekyll_commonmark_spec.rb
+++ b/spec/jekyll_commonmark_spec.rb
@@ -66,7 +66,7 @@ describe(Jekyll::Converters::Markdown::CommonMark) do
                 <span class="na">title</span><span class="pi">:</span>
                 <span class="s">CommonMark Test</span>
                 <span class="na">verbose</span><span class="pi">:</span>
-                <span class="no">true</span>
+                <span class="kc">true</span>
                 <span class="na">atm_pin</span><span class="pi">:</span>
                 <span class="m">1234</span>
               </code>


### PR DESCRIPTION
With at least rouge 4.x, the boolean 'true' is decorated with the CSS class 'kc', instead of 'no'. Maybe the output string of this test should be converted to a regexp to accept the two possibilities?

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1042172